### PR TITLE
Create ParseNUH to follow proper NUH-splitting rules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,4 +6,5 @@ require (
 	github.com/DanielOaks/go-idn v0.0.0-20160120021903-76db0e10dc65
 	github.com/goshuirc/eventmgr v0.0.0-20170615162049-060479027c93
 	golang.org/x/text v0.3.2
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -5,3 +5,6 @@ github.com/goshuirc/eventmgr v0.0.0-20170615162049-060479027c93/go.mod h1:bjJFM4
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/ircutils/userhost_test.go
+++ b/ircutils/userhost_test.go
@@ -1,0 +1,131 @@
+// written by Daniel Oaks <daniel@danieloaks.net>
+// released under the ISC license
+
+package ircutils
+
+import (
+	"fmt"
+	"testing"
+
+	"gopkg.in/yaml.v2"
+)
+
+const nuhTests = `
+# IRC parser tests
+# splitting userhosts into atoms
+
+# Written in 2015 by Daniel Oaks <daniel@danieloaks.net>
+#
+# To the extent possible under law, the author(s) have dedicated all copyright
+# and related and neighboring rights to this software to the public domain
+# worldwide. This software is distributed without any warranty.
+#
+# You should have received a copy of the CC0 Public Domain Dedication along
+# with this software. If not, see
+# <http://creativecommons.org/publicdomain/zero/1.0/>.
+
+tests:
+  # source is the usthost
+
+  # the atoms dict has the keys:
+  #   * nick: nick string
+  #   * user: user string
+  #   * host: host string
+  # if a key does not exist, assume it is an empty string
+
+  # simpler
+  - source: "coolguy"
+    atoms:
+      nick: "coolguy"
+
+  # simple
+  - source: "coolguy!ag@127.0.0.1"
+    atoms:
+      nick: "coolguy"
+      user: "ag"
+      host: "127.0.0.1"
+
+  - source: "coolguy!~ag@localhost"
+    atoms:
+      nick: "coolguy"
+      user: "~ag"
+      host: "localhost"
+
+  # without atoms
+  - source: "!ag@127.0.0.1"
+    atoms:
+      user: "ag"
+      host: "127.0.0.1"
+
+  - source: "coolguy!@127.0.0.1"
+    atoms:
+      nick: "coolguy"
+      host: "127.0.0.1"
+
+  - source: "coolguy@127.0.0.1"
+    atoms:
+      nick: "coolguy"
+      host: "127.0.0.1"
+
+  - source: "coolguy!ag@"
+    atoms:
+      nick: "coolguy"
+      user: "ag"
+
+  - source: "coolguy!ag"
+    atoms:
+      nick: "coolguy"
+      user: "ag"
+
+  # weird control codes, does happen
+  - source: "coolguy!ag@net\x035w\x03ork.admin"
+    atoms:
+      nick: "coolguy"
+      user: "ag"
+      host: "net\x035w\x03ork.admin"
+
+  - source: "coolguy!~ag@n\x02et\x0305w\x0fork.admin"
+    atoms:
+      nick: "coolguy"
+      user: "~ag"
+      host: "n\x02et\x0305w\x0fork.admin"
+`
+
+type NUHSplitTest struct {
+	Source string
+	Atoms  struct {
+		Nick string
+		User string
+		Host string
+	}
+}
+
+type TestFile struct {
+	Tests []NUHSplitTest
+}
+
+func assertEqualNUH(found, expected NUH) {
+	if found.Nick != expected.Nick || found.User != expected.User || found.Host != expected.Host {
+		panic(fmt.Sprintf("expected %#v, found %#v", expected.Canonical(), found.Canonical()))
+	}
+}
+func TestSplittingNUH(t *testing.T) {
+	var tF *TestFile
+	err := yaml.Unmarshal([]byte(nuhTests), &tF)
+	if err != nil {
+		t.Errorf("could not load nuh splitting test file [%q]", err.Error())
+	}
+
+	for _, test := range tF.Tests {
+		out, err := ParseNUH(test.Source)
+		if err != nil {
+			t.Errorf("could not parse nuh test [%s] got [%s]", test.Source, err.Error())
+		}
+		comp := NUH{
+			Nick: test.Atoms.Nick,
+			User: test.Atoms.User,
+			Host: test.Atoms.Host,
+		}
+		assertEqualNUH(out, comp)
+	}
+}


### PR DESCRIPTION
Fixes #57, this function should do everything we need it to. I also renamed the `UserHost` struct to `NUH`, since that's a more accurate name for it. In the test, I'm embedding the entire test file from the parser-tests repo [here](https://github.com/ircdocs/parser-tests/blob/master/tests/userhost-split.yaml), so that we can really easily update it later on (I don't really wanna be going and grabbing it over the internet when the tests are run or any weird stuff like that, this should be fine I think.

I tried to use IndexByte and all like the new line-parsing function does, think this should be fairly small and performant.