### PR TITLE
rename Message.Prefix to Source

### DIFF
--- a/ircevent/README.markdown
+++ b/ircevent/README.markdown
@@ -27,7 +27,7 @@ irc := ircevent.Connection{
 irc.AddConnectCallback(func(e ircmsg.Message) { irc.Join("#ircevent-test") })
 
 irc.AddCallback("PRIVMSG", func(event ircmsg.Message) {
-	// event.Prefix is the source;
+	// event.Source is the source;
 	// event.Params[0] is the target (the channel or nickname the message was sent to)
 	// and event.Params[1] is the message itself
 });

--- a/ircmsg/message.go
+++ b/ircmsg/message.go
@@ -65,7 +65,7 @@ var (
 // extended by the IRCv3 Message Tags specification with the introduction
 // of message tags.
 type Message struct {
-	Prefix         string
+	Source         string
 	Command        string
 	Params         []string
 	forceTrailing  bool
@@ -157,7 +157,7 @@ func (msg *Message) ClientOnlyTags() map[string]string {
 // Nick returns the name component of the message source (typically a nickname,
 // but possibly a server name).
 func (msg *Message) Nick() (nick string) {
-	nuh, err := ParseNUH(msg.Prefix)
+	nuh, err := ParseNUH(msg.Source)
 	if err == nil {
 		return nuh.Name
 	}
@@ -167,7 +167,7 @@ func (msg *Message) Nick() (nick string) {
 // NUH returns the source of the message as a parsed NUH ("nick-user-host");
 // if the source is not well-formed as a NUH, it returns an error.
 func (msg *Message) NUH() (nuh NUH, err error) {
-	return ParseNUH(msg.Prefix)
+	return ParseNUH(msg.Source)
 }
 
 // ParseLine creates and returns a message from the given IRC line.
@@ -245,15 +245,15 @@ func parseLine(line string, maxTagDataLength int, truncateLen int) (ircmsg Messa
 	// by one or more ASCII SPACE characters"
 	line = trimInitialSpaces(line)
 
-	// prefix
+	// source
 	if 0 < len(line) && line[0] == ':' {
-		prefixEnd := strings.IndexByte(line, ' ')
-		if prefixEnd == -1 {
+		sourceEnd := strings.IndexByte(line, ' ')
+		if sourceEnd == -1 {
 			return ircmsg, ErrorLineIsEmpty
 		}
-		ircmsg.Prefix = line[1:prefixEnd]
-		// skip over the prefix and the separating space
-		line = line[prefixEnd+1:]
+		ircmsg.Source = line[1:sourceEnd]
+		// skip over the source and the separating space
+		line = line[sourceEnd+1:]
 	}
 
 	line = trimInitialSpaces(line)
@@ -328,8 +328,8 @@ func (ircmsg *Message) parseTags(tags string) (err error) {
 }
 
 // MakeMessage provides a simple way to create a new Message.
-func MakeMessage(tags map[string]string, prefix string, command string, params ...string) (ircmsg Message) {
-	ircmsg.Prefix = prefix
+func MakeMessage(tags map[string]string, source string, command string, params ...string) (ircmsg Message) {
+	ircmsg.Source = source
 	ircmsg.Command = command
 	ircmsg.Params = params
 	ircmsg.UpdateTags(tags)
@@ -427,9 +427,9 @@ func (ircmsg *Message) line(tagLimit, clientOnlyTagDataLimit, serverAddedTagData
 		return nil, ErrorTagsTooLong
 	}
 
-	if len(ircmsg.Prefix) > 0 {
+	if len(ircmsg.Source) > 0 {
 		buf.WriteByte(':')
-		buf.WriteString(ircmsg.Prefix)
+		buf.WriteString(ircmsg.Source)
 		buf.WriteByte(' ')
 	}
 

--- a/ircmsg/message_test.go
+++ b/ircmsg/message_test.go
@@ -268,7 +268,7 @@ var testMessages = []Message{
 	{
 		tags:           map[string]string{"time": "2019-02-27T04:38:57.489Z", "account": "dan-"},
 		clientOnlyTags: map[string]string{"+status": "typing"},
-		Prefix:         "dan-!~user@example.com",
+		Source:         "dan-!~user@example.com",
 		Command:        "TAGMSG",
 	},
 	{
@@ -282,39 +282,39 @@ var testMessages = []Message{
 	},
 	{
 		tags:    map[string]string{"time": "2019-02-27T04:38:57.489Z", "account": "dan-"},
-		Prefix:  "dan-!~user@example.com",
+		Source:  "dan-!~user@example.com",
 		Command: "PRIVMSG",
 		Params:  []string{"#ircv3", ":smiley:"},
 	},
 	{
 		tags:    map[string]string{"time": "2019-02-27T04:38:57.489Z", "account": "dan-"},
-		Prefix:  "dan-!~user@example.com",
+		Source:  "dan-!~user@example.com",
 		Command: "PRIVMSG",
 		Params:  []string{"#ircv3", "\x01ACTION writes some specs!\x01"},
 	},
 	{
-		Prefix:  "dan-!~user@example.com",
+		Source:  "dan-!~user@example.com",
 		Command: "PRIVMSG",
 		Params:  []string{"#ircv3", ": long trailing command with langue française in it"},
 	},
 	{
-		Prefix:  "dan-!~user@example.com",
+		Source:  "dan-!~user@example.com",
 		Command: "PRIVMSG",
 		Params:  []string{"#ircv3", " : long trailing command with langue française in it "},
 	},
 	{
-		Prefix:  "shivaram",
+		Source:  "shivaram",
 		Command: "KLINE",
 		Params:  []string{"ANDKILL", "24h", "tkadich", "your", "client", "is", "disconnecting", "too", "much"},
 	},
 	{
 		tags:    map[string]string{"time": "2019-02-27T06:01:23.545Z", "draft/msgid": "xjmgr6e4ih7izqu6ehmrtrzscy"},
-		Prefix:  "שיברם",
+		Source:  "שיברם",
 		Command: "PRIVMSG",
 		Params:  []string{"ויקם מלך חדש על מצרים אשר לא ידע את יוסף"},
 	},
 	{
-		Prefix:  "shivaram!~user@2001:0db8::1",
+		Source:  "shivaram!~user@2001:0db8::1",
 		Command: "KICK",
 		Params:  []string{"#darwin", "devilbat", ":::::::::::::: :::::::::::::"},
 	},
@@ -338,7 +338,7 @@ func TestEncodeDecode(t *testing.T) {
 
 func TestForceTrailing(t *testing.T) {
 	message := Message{
-		Prefix:  "shivaram",
+		Source:  "shivaram",
 		Command: "PRIVMSG",
 		Params:  []string{"#darwin", "nice"},
 	}
@@ -362,7 +362,7 @@ func TestForceTrailing(t *testing.T) {
 func TestErrorLineTooLongGeneration(t *testing.T) {
 	message := Message{
 		tags:    map[string]string{"draft/msgid": "SAXV5OYJUr18CNJzdWa1qQ"},
-		Prefix:  "shivaram",
+		Source:  "shivaram",
 		Command: "PRIVMSG",
 		Params:  []string{"aaaaaaaaaaaaaaaaaaaaa"},
 	}


### PR DESCRIPTION
I'm envisioning this as the last major API break, after which we will tag v0.1.0 with the intention of maintaining backwards compatibility. If we successfully keep to that intention we will subsequently tag v1.0.0.