### PR TITLE
fix #79

### DIFF
--- a/ircevent/irc.go
+++ b/ircevent/irc.go
@@ -285,7 +285,12 @@ func (irc *Connection) Loop() {
 			if irc.Debug {
 				irc.Log.Printf("Waiting %v to reconnect", delay)
 			}
-			time.Sleep(delay)
+			t := time.NewTimer(delay)
+			select {
+			case <-t.C:
+			case <-irc.reconnSig:
+				t.Stop()
+			}
 		}
 
 		lastReconnect = time.Now()
@@ -534,6 +539,10 @@ func (irc *Connection) Connected() bool {
 // TODO try to ensure buffered messages are sent?
 func (irc *Connection) Reconnect() {
 	irc.closeEnd()
+	select {
+	case irc.reconnSig <- empty{}:
+	default:
+	}
 }
 
 func (irc *Connection) closeEnd() {
@@ -616,6 +625,11 @@ func (irc *Connection) Connect() (err error) {
 		}
 		if irc.Version == "" {
 			irc.Version = Version
+		}
+		// this only runs on first Connect() invocation;
+		// unlike other synch primitives it is shared across reconnections:
+		if irc.reconnSig == nil {
+			irc.reconnSig = make(chan empty)
 		}
 		return nil
 	}()

--- a/ircevent/irc_struct.go
+++ b/ircevent/irc_struct.go
@@ -68,6 +68,7 @@ type Connection struct {
 	stateMutex sync.Mutex     // innermost mutex: don't block while holding this
 	end        chan empty     // closing this causes the goroutines to exit
 	pwrite     chan []byte    // receives IRC lines to be sent to the socket
+	reconnSig  chan empty     // interrupts sleep in between reconnects (#79)
 	wg         sync.WaitGroup // after closing end, wait on this for all the goroutines to stop
 	socket     net.Conn
 	lastError  error


### PR DESCRIPTION
An explicit Reconnect() should interrupt the ReconnectFreq-based delay between
automatic reconnection attempts.

Testing patch:

```diff
diff --git a/ircevent/examples/simple.go b/ircevent/examples/simple.go
index 70d9270..8e08de2 100644
--- a/ircevent/examples/simple.go
+++ b/ircevent/examples/simple.go
@@ -4,6 +4,8 @@ import (
 	"crypto/tls"
 	"log"
 	"os"
+	"os/signal"
+	"syscall"
 	"strconv"
 	"strings"
 
@@ -63,6 +65,14 @@ func main() {
 			irc.Privmsg(e.Params[0], e.Params[2])
 		}
 	})
+	reconnSignal := make(chan os.Signal, 1)
+	signal.Notify(reconnSignal, syscall.SIGHUP)
+	go func() {
+		for _ = range reconnSignal {
+			log.Printf("signal caught\n")
+			irc.Reconnect()
+		}
+	}()
 	// example client-to-client extension via message-tags:
 	// have the bot maintain a running sum of integers
 	var sum int64 // doesn't need synchronization as long as it's only visible from a single callback
```