### PR TITLE
ircmsg: UTF8-aware truncation during parsing

### DIFF
--- a/ircmsg/message.go
+++ b/ircmsg/message.go
@@ -238,7 +238,7 @@ func parseLine(line string, maxTagDataLength int, truncateLen int) (ircmsg Messa
 	// truncate if desired
 	if truncateLen != 0 && truncateLen < len(line) {
 		err = ErrorBodyTooLong
-		line = line[:truncateLen]
+		line = TruncateUTF8Safe(line, truncateLen)
 	}
 
 	// modern: "These message parts, and parameters themselves, are separated

--- a/ircmsg/unicode.go
+++ b/ircmsg/unicode.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2021 Shivaram Lingamneni
+// Released under the MIT License
+
+package ircmsg
+
+import (
+	"unicode/utf8"
+)
+
+// TruncateUTF8Safe truncates a message, respecting UTF8 boundaries. If a message
+// was originally valid UTF8, TruncateUTF8Safe will not make it invalid; instead
+// it will truncate additional bytes as needed, back to the last valid
+// UTF8-encoded codepoint. If a message is not UTF8, TruncateUTF8Safe will truncate
+// at most 3 additional bytes before giving up.
+func TruncateUTF8Safe(message string, byteLimit int) (result string) {
+	if len(message) <= byteLimit {
+		return message
+	}
+	message = message[:byteLimit]
+	for i := 0; i < (utf8.UTFMax - 1); i++ {
+		r, n := utf8.DecodeLastRuneInString(message)
+		if r == utf8.RuneError && n <= 1 {
+			message = message[:len(message)-1]
+		} else {
+			break
+		}
+	}
+	return message
+}

--- a/ircmsg/unicode_test.go
+++ b/ircmsg/unicode_test.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2021 Shivaram Lingamneni
+// Released under the MIT License
+
+package ircmsg
+
+import (
+	"testing"
+)
+
+func TestTruncateUTF8(t *testing.T) {
+	assertEqual(TruncateUTF8Safe("fffff", 512), "fffff")
+	assertEqual(TruncateUTF8Safe("fffff", 5), "fffff")
+	assertEqual(TruncateUTF8Safe("ffffff", 5), "fffff")
+	assertEqual(TruncateUTF8Safe("ffffffffff", 5), "fffff")
+
+	assertEqual(TruncateUTF8Safe("12345🐬", 9), "12345🐬")
+	assertEqual(TruncateUTF8Safe("12345🐬", 8), "12345")
+	assertEqual(TruncateUTF8Safe("12345🐬", 7), "12345")
+	assertEqual(TruncateUTF8Safe("12345🐬", 6), "12345")
+	assertEqual(TruncateUTF8Safe("12345", 5), "12345")
+
+	assertEqual(TruncateUTF8Safe("\xff\xff\xff\xff\xff\xff", 512), "\xff\xff\xff\xff\xff\xff")
+	assertEqual(TruncateUTF8Safe("\xff\xff\xff\xff\xff\xff", 6), "\xff\xff\xff\xff\xff\xff")
+	// shouldn't truncate the whole string
+	assertEqual(TruncateUTF8Safe("\xff\xff\xff\xff\xff\xff", 5), "\xff\xff")
+}

--- a/ircmsg/unicode_test.go
+++ b/ircmsg/unicode_test.go
@@ -24,3 +24,15 @@ func TestTruncateUTF8(t *testing.T) {
 	// shouldn't truncate the whole string
 	assertEqual(TruncateUTF8Safe("\xff\xff\xff\xff\xff\xff", 5), "\xff\xff")
 }
+
+func BenchmarkTruncateUTF8Invalid(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		TruncateUTF8Safe("\xff\xff\xff\xff\xff\xff", 5)
+	}
+}
+
+func BenchmarkTruncateUTF8Valid(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		TruncateUTF8Safe("12345🐬", 8)
+	}
+}

--- a/ircutils/unicode.go
+++ b/ircutils/unicode.go
@@ -7,24 +7,11 @@ import (
 	"strings"
 	"unicode"
 	"unicode/utf8"
+
+	"github.com/ergochat/irc-go/ircmsg"
 )
 
-// truncate a message, taking care not to make valid UTF8 into invalid UTF8
-func TruncateUTF8Safe(message string, byteLimit int) (result string) {
-	if len(message) <= byteLimit {
-		return message
-	}
-	message = message[:byteLimit]
-	for i := 0; i < (utf8.UTFMax - 1); i++ {
-		r, n := utf8.DecodeLastRuneInString(message)
-		if r == utf8.RuneError && n <= 1 {
-			message = message[:len(message)-1]
-		} else {
-			break
-		}
-	}
-	return message
-}
+var TruncateUTF8Safe = ircmsg.TruncateUTF8Safe
 
 // Sanitizes human-readable text to make it safe for IRC;
 // assumes UTF-8 and uses the replacement character where

--- a/ircutils/unicode_test.go
+++ b/ircutils/unicode_test.go
@@ -14,23 +14,6 @@ func assertEqual(found, expected interface{}) {
 		panic(fmt.Sprintf("expected %#v, found %#v", expected, found))
 	}
 }
-func TestTruncateUTF8(t *testing.T) {
-	assertEqual(TruncateUTF8Safe("fffff", 512), "fffff")
-	assertEqual(TruncateUTF8Safe("fffff", 5), "fffff")
-	assertEqual(TruncateUTF8Safe("ffffff", 5), "fffff")
-	assertEqual(TruncateUTF8Safe("ffffffffff", 5), "fffff")
-
-	assertEqual(TruncateUTF8Safe("12345🐬", 9), "12345🐬")
-	assertEqual(TruncateUTF8Safe("12345🐬", 8), "12345")
-	assertEqual(TruncateUTF8Safe("12345🐬", 7), "12345")
-	assertEqual(TruncateUTF8Safe("12345🐬", 6), "12345")
-	assertEqual(TruncateUTF8Safe("12345", 5), "12345")
-
-	assertEqual(TruncateUTF8Safe("\xff\xff\xff\xff\xff\xff", 512), "\xff\xff\xff\xff\xff\xff")
-	assertEqual(TruncateUTF8Safe("\xff\xff\xff\xff\xff\xff", 6), "\xff\xff\xff\xff\xff\xff")
-	// shouldn't truncate the whole string
-	assertEqual(TruncateUTF8Safe("\xff\xff\xff\xff\xff\xff", 5), "\xff\xff")
-}
 
 func TestSanitize(t *testing.T) {
 	assertEqual(SanitizeText("abc", 10), "abc")


### PR DESCRIPTION
A message that exceeds the length limit is a protocol violation, so handling is implementation-defined and it's not really a correctness issue for us to truncate it additionally.

Also move TruncateUTF8Safe into ircmsg (providing an alias in ircutils for API compatibility).