### PR TITLE
fix #111

### DIFF
--- a/ircevent/examples/proxy.go
+++ b/ircevent/examples/proxy.go
@@ -24,7 +24,7 @@ func getenv(key, defaultValue string) (value string) {
 
 func main() {
 	nick := getenv("IRCEVENT_NICK", "robot")
-	server := getenv("IRCEVENT_SERVER", "testnet.oragono.io:6697")
+	server := getenv("IRCEVENT_SERVER", "testnet.ergo.chat:6697")
 	channel := getenv("IRCEVENT_CHANNEL", "#ircevent-test")
 	saslLogin := os.Getenv("IRCEVENT_SASL_LOGIN")
 	saslPassword := os.Getenv("IRCEVENT_SASL_PASSWORD")

--- a/ircevent/examples/simple.go
+++ b/ircevent/examples/simple.go
@@ -21,7 +21,7 @@ func getenv(key, defaultValue string) (value string) {
 
 func main() {
 	nick := getenv("IRCEVENT_NICK", "robot")
-	server := getenv("IRCEVENT_SERVER", "testnet.oragono.io:6697")
+	server := getenv("IRCEVENT_SERVER", "testnet.ergo.chat:6697")
 	channel := getenv("IRCEVENT_CHANNEL", "#ircevent-test")
 	saslLogin := os.Getenv("IRCEVENT_SASL_LOGIN")
 	saslPassword := os.Getenv("IRCEVENT_SASL_PASSWORD")

--- a/ircevent/irc.go
+++ b/ircevent/irc.go
@@ -632,6 +632,9 @@ func (irc *Connection) Connect() (err error) {
 		if irc.User == "" {
 			irc.User = irc.Nick
 		}
+		if irc.RealName == "" {
+			irc.RealName = irc.User
+		}
 		if irc.Log == nil {
 			irc.Log = log.New(os.Stdout, "", log.LstdFlags)
 		}
@@ -704,7 +707,7 @@ func (irc *Connection) Connect() (err error) {
 	irc.wg.Add(3)
 	irc.capsChan = make(chan capResult, len(irc.RequestCaps))
 	irc.saslChan = make(chan saslResult, 1)
-	irc.welcomeChan = make(chan empty, 1)
+	irc.welcomeChan = make(chan empty)
 	irc.registered = false
 	irc.isupportPartial = make(map[string]string)
 	irc.isupport = nil
@@ -730,6 +733,10 @@ func (irc *Connection) Connect() (err error) {
 		}
 	}()
 
+	return irc.performHandshake()
+}
+
+func (irc *Connection) performHandshake() error {
 	if len(irc.WebIRC) > 0 {
 		irc.Send("WEBIRC", irc.WebIRC...)
 	}
@@ -738,93 +745,96 @@ func (irc *Connection) Connect() (err error) {
 		irc.Send("PASS", irc.Password)
 	}
 
-	err = irc.negotiateCaps()
-	if err != nil {
-		return err
-	}
+	remainingCaps := len(irc.RequestCaps)
+	capsRequested := remainingCaps != 0
+	acknowledgedCaps := make([]string, 0, remainingCaps)
 
-	realname := irc.User
-	if irc.RealName != "" {
-		realname = irc.RealName
+	if capsRequested {
+		// get all CAP values if available
+		irc.Send("CAP", "LS", "302")
+		// then blindly request all CAPs we know about
+		for _, capab := range irc.RequestCaps {
+			irc.Send("CAP", "REQ", capab)
+		}
 	}
+	// then send NICK and USER
 	irc.Send("NICK", irc.PreferredNick())
-	irc.Send("USER", irc.User, "s", "e", realname)
-	timeout := time.NewTimer(irc.Timeout)
-	defer timeout.Stop()
-	select {
-	case <-irc.welcomeChan:
-	case <-irc.end:
-		err = ServerDisconnected
-	case <-timeout.C:
-		err = ServerTimedOut
-	}
-	return
-}
+	irc.Send("USER", irc.User, "s", "e", irc.RealName)
 
-// Negotiate IRCv3 capabilities
-func (irc *Connection) negotiateCaps() error {
-	if len(irc.RequestCaps) == 0 {
-		return nil
-	}
+	// Three possibilities:
+	// 1. The server doesn't support CAP or we didn't request any CAPs;
+	// the server will terminate registration with NICK/USER and send 001
+	// 2. The server supports CAPs and will start sending CAP LS / ACK / NAK replies
+	// 3. We time out before getting an intelligible response, so set a timer:
+	timer := time.NewTimer(irc.Timeout)
+	defer timer.Stop()
 
-	var acknowledgedCaps []string
-	defer func() {
-		irc.processAckedCaps(acknowledgedCaps)
-	}()
-
-	irc.Send("CAP", "LS", "302")
-	defer func() {
-		irc.Send("CAP", "END")
-	}()
-
-	remaining_caps := len(irc.RequestCaps)
-
-	timer := time.NewTimer(CAPTimeout)
-	for remaining_caps > 0 {
+CAPLOOP:
+	for {
 		select {
 		case result := <-irc.capsChan:
-			timer.Stop()
-			remaining_caps--
+			remainingCaps--
 			if result.ack {
 				acknowledgedCaps = append(acknowledgedCaps, result.capName)
 			}
+			if remainingCaps <= 0 {
+				break CAPLOOP // got ACK or NAK for all our CAPs
+			}
+		case <-irc.welcomeChan:
+			break CAPLOOP // server does not support CAP
 		case <-timer.C:
-			// The server probably doesn't implement CAP LS, which is "normal".
-			return nil
+			return ServerTimedOut
 		case <-irc.end:
 			return ServerDisconnected
 		}
 	}
 
-	saslError := func(err error) error {
-		if !irc.SASLOptional {
-			return err
-		} else {
-			return nil
-		}
-	}
+	irc.processAckedCaps(acknowledgedCaps)
 
-	if irc.UseSASL {
-		if !sliceContains("sasl", acknowledgedCaps) {
-			return saslError(SASLFailed)
-		} else {
-			irc.Send("AUTHENTICATE", irc.SASLMech)
-		}
-		timeout := time.NewTimer(CAPTimeout)
-		defer timeout.Stop()
+	saslSucceeded := false
+	var saslError error
+
+	if irc.UseSASL && sliceContains("sasl", acknowledgedCaps) {
+		// perform SASL and wait synchronously for the result;
+		// we must wait because on conventional ircd+services stacks,
+		// CAP END will terminate an in-progress SASL session
+		irc.Send("AUTHENTICATE", irc.SASLMech)
+
 		select {
 		case res := <-irc.saslChan:
-			if res.Failed {
-				return saslError(res.Err)
+			saslSucceeded = !res.Failed
+			if !saslSucceeded {
+				saslError = res.Err
 			}
-		case <-timeout.C:
-			// if we expect to be able to SASL, failure to SASL should be treated
-			// as a connection error:
-			return saslError(SASLFailed)
+		case <-timer.C:
+			// technically we could proceed, but our view of the
+			// registration timeout has expired
+			return ServerTimedOut
 		case <-irc.end:
 			return ServerDisconnected
 		}
 	}
 
-	return nil
+	if irc.UseSASL && !irc.SASLOptional && !saslSucceeded {
+		if saslError == nil {
+			saslError = SASLFailed
+		}
+		return saslError
+	}
+
+	// if we did successful CAP negotiation with the server
+	// then we need CAP END to terminate registration
+	if capsRequested && remainingCaps <= 0 {
+		irc.Send("CAP", "END")
+	}
+
+	// wait for registration to complete, or fail
+	select {
+	case <-irc.welcomeChan:
+		return nil
+	case <-timer.C:
+		return ServerTimedOut
+	case <-irc.end:
+		return ServerDisconnected
+	}
 }

--- a/ircevent/irc_callback.go
+++ b/ircevent/irc_callback.go
@@ -471,11 +471,11 @@ func (irc *Connection) handleRplWelcome(e ircmsg.Message) {
 }
 
 func (irc *Connection) handleRegistration(e ircmsg.Message) {
+	becameRegistered := false
 	// wake up Connect() if applicable
 	defer func() {
-		select {
-		case irc.welcomeChan <- empty{}:
-		default:
+		if becameRegistered {
+			close(irc.welcomeChan)
 		}
 	}()
 
@@ -486,6 +486,7 @@ func (irc *Connection) handleRegistration(e ircmsg.Message) {
 		return
 	}
 	irc.registered = true
+	becameRegistered = true
 
 	// mark the isupport complete
 	irc.isupport = irc.isupportPartial
@@ -578,25 +579,10 @@ func (irc *Connection) handleCAP(e ircmsg.Message) {
 }
 
 func (irc *Connection) handleCAPLS(params []string) {
-	var capsToReq, capsNotFound []string
-	defer func() {
-		for _, c := range capsToReq {
-			irc.Send("CAP", "REQ", c)
-		}
-		for _, c := range capsNotFound {
-			select {
-			case irc.capsChan <- capResult{capName: c, ack: false}:
-			default:
-			}
-		}
-	}()
-
 	irc.stateMutex.Lock()
 	defer irc.stateMutex.Unlock()
 
 	if irc.registered {
-		// TODO server could probably trick us into panic here by sending
-		// additional LS before the end of registration
 		return
 	}
 
@@ -608,20 +594,9 @@ func (irc *Connection) handleCAPLS(params []string) {
 	// CAP * LS * :account-notify away-notify [...]
 	// and end with a 3-parameter form:
 	// CAP * LS :userhost-in-names znc.in/playback [...]
-	final := len(params) == 1
 	for _, token := range strings.Fields(params[len(params)-1]) {
 		name, value := splitCAPToken(token)
 		irc.capsAdvertised[name] = value
-	}
-
-	if final {
-		for _, c := range irc.RequestCaps {
-			if _, ok := irc.capsAdvertised[c]; ok {
-				capsToReq = append(capsToReq, c)
-			} else {
-				capsNotFound = append(capsNotFound, c)
-			}
-		}
 	}
 }
 

--- a/ircevent/irc_test.go
+++ b/ircevent/irc_test.go
@@ -344,6 +344,87 @@ func TestConnectionCallbacks(t *testing.T) {
 	assertEqual(disconnectCalled, true)
 }
 
+func TestCAPHandling(t *testing.T) {
+	var testCases = []struct {
+		name   string
+		caps   []string
+		result []string
+	}{
+		{
+			name:   "no caps",
+			caps:   nil,
+			result: nil,
+		},
+		{
+			name:   "one invalid cap",
+			caps:   []string{"ergo.chat/nonexistent"},
+			result: nil,
+		},
+		{
+			name:   "one valid cap",
+			caps:   []string{"message-tags"},
+			result: []string{"message-tags"},
+		},
+		{
+			name:   "one valid cap, one invalid",
+			caps:   []string{"ergo.chat/nonexistent", "message-tags"},
+			result: []string{"message-tags"},
+		},
+		{
+			name:   "multiple caps, one invalid",
+			caps:   []string{"server-time", "batch", "echo-message", "labeled-response", "account-tag", "ergo.chat/nonexistent", "message-tags"},
+			result: []string{"account-tag", "batch", "echo-message", "labeled-response", "message-tags", "server-time"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			rand.Seed(time.Now().UnixNano())
+			ircnick := randStr(8)
+			irccon1 := connForTesting(ircnick, "IRCTest1", false)
+			irccon1.RequestCaps = tc.caps
+			debugTest(irccon1)
+			resultChan := make(chan map[string]string, 1)
+			disconnectCalled := false
+			irccon1.AddConnectCallback(func(e ircmsg.Message) {
+				resultChan <- irccon1.ISupport()
+			})
+			irccon1.AddDisconnectCallback(func(e ircmsg.Message) {
+				disconnectCalled = true
+			})
+			err := irccon1.Connect()
+			if err != nil {
+				panic(err)
+			}
+			loopExited := make(chan empty)
+			go func() {
+				irccon1.Loop()
+				close(loopExited)
+			}()
+			<-resultChan
+			// should successfully req message-tags, ignoring the nonexistent cap
+			capsAcked := sortAckedCaps(irccon1.capsAcked)
+			assertEqual(capsAcked, tc.result)
+			assertEqual(disconnectCalled, false)
+			irccon1.Quit()
+			<-loopExited
+			assertEqual(disconnectCalled, true)
+		})
+	}
+}
+
+func sortAckedCaps(caps map[string]string) (result []string) {
+	if len(caps) == 0 {
+		return nil
+	}
+	result = make([]string, 0, len(caps))
+	for c := range caps {
+		result = append(result, c)
+	}
+	sort.Strings(result)
+	return result
+}
+
 func mustParse(line string) ircmsg.Message {
 	msg, err := ircmsg.ParseLine(line)
 	if err != nil {


### PR DESCRIPTION
Immediately after NICK and USER, send CAP LS and CAP REQ:

1. Comply with the spec, which requires sending them immediately
2. Improve compatibility with legacy servers that don't support CAP at all (we no longer have to time out waiting for CAP)
3. Remove a roundtrip waiting for the CAP LS reply, at the cost of sending CAP REQ's that will fail (since we no longer filter for presence in the CAP LS reply)

Tested a number of scenarios:

1. In the unit tests: 0-n caps that exist or don't exist (against local Ergo)
2. Against Dalnet (which doesn't support CAP at all); we send CAP LS and CAP REQ up front, then receive 001 and don't send CAP END (which would produce a harmless but undesirable `ERR_UNKNOWNCOMMAND`)