### PR TITLE
ircevent: add MaxMsgByteLen

### DIFF
--- a/ircevent/irc.go
+++ b/ircevent/irc.go
@@ -501,40 +501,43 @@ func (irc *Connection) CurrentNick() string {
 	return irc.currentNick
 }
 
-// Calculate the max message size based on the premable byte length
-//
+func (irc *Connection) getUserHost() string {
+	irc.stateMutex.Lock()
+	defer irc.stateMutex.Unlock()
+	return irc.userHost
+}
+
+// Calculate the max message size for PRIVMSG or NOTICE, after accounting
+// for protocol overhead incurred when the server relays the message.
 // This may be used to ensure sent messages do not exceed the IRC 512 byte
-// limit.
-func (irc *Connection) MaxMsgByteLen(command, target string) int {
+// limit (which would cause them to either be truncated or rejected by the
+// ircd). Note that this value is not a strict guarantee because the server
+// can change the client's NUH unilaterally at any time; implementations may
+// wish to use a more conservative constant maximum instead.
+func (irc *Connection) MaxMsgByteLen(target string) int {
 	nick := irc.CurrentNick()
-	var userHost string
-	if irc.userHost != "" {
-		userHost = strings.TrimLeft(irc.userHost, "+-")
+	userhost := irc.getUserHost()
+	var userhostLen int
+	if userhost != "" {
+		userhostLen = len(userhost)
 	} else {
-		// Max length defaults, they are used if we can't get the values from
-		// ISUPPORT
-		hostLen := 63
-		userLen := 20
-		if userLenStr := irc.ISupport()["USERLEN"]; userLenStr != "" {
-			iSupportUserLen, err := strconv.Atoi(userLenStr)
-			if err == nil {
-				userLen = iSupportUserLen
-			}
-		}
-		if hostLenStr := irc.ISupport()["HOSTLEN"]; hostLenStr != "" {
-			iSupportHostLen, err := strconv.Atoi(hostLenStr)
-			if err == nil {
-				hostLen = iSupportHostLen
-			}
-		}
-		userHost = fmt.Sprintf(
-			"%s@%s",
-			strings.Repeat("A", userLen),
-			strings.Repeat("A", hostLen),
-		)
+		userhostLen = 96 // sane default
 	}
-	preamble := fmt.Sprintf(":%s!%s %s %s :\r\n", nick, userHost, command, target)
-	return 512 - len(preamble)
+
+	// :nick!user@host PRIVMSG #target :payload\r\n
+	result := 512
+	result -= 1 // :
+	result -= len(nick)
+	result -= 1 // !
+	result -= userhostLen
+	result -= 1 // space
+	result -= 7 // PRIVMSG
+	result -= 1 // space
+	result -= len(target)
+	result -= 2 // space after target, : for trailing
+	// payload goes here
+	result -= 2 // \r\n
+	return result
 }
 
 // Returns the expected or desired nickname for the connection;
@@ -656,6 +659,7 @@ func (irc *Connection) Connect() (err error) {
 		irc.running = false
 		irc.socket = nil
 		irc.currentNick = ""
+		irc.userHost = ""
 		irc.lastError = nil
 		irc.pingSent = false
 
@@ -867,9 +871,6 @@ CAPLOOP:
 	// wait for registration to complete, or fail
 	select {
 	case <-irc.welcomeChan:
-		// Send a USERHOST query so we can populate irc.userHost and use its
-		// value to accurately determine the MaxMsgByteLen()
-		irc.Send("USERHOST", irc.CurrentNick())
 		return nil
 	case <-timer.C:
 		return ServerTimedOut

--- a/ircevent/irc.go
+++ b/ircevent/irc.go
@@ -501,10 +501,27 @@ func (irc *Connection) CurrentNick() string {
 	return irc.currentNick
 }
 
-func (irc *Connection) getUserHost() string {
+func (irc *Connection) getOrRequestUserHost() (currentNick, userHost string) {
+	requestUserhost := false
+	defer func() {
+		if requestUserhost {
+			// legacy fallback for learning the userhost
+			irc.AddCallback(RPL_WHOREPLY, irc.handleRplWhoReply)
+			irc.Send("WHO", currentNick)
+		}
+	}()
+
 	irc.stateMutex.Lock()
 	defer irc.stateMutex.Unlock()
-	return irc.userHost
+
+	// query for the userhost if this is the first time we were asked about it
+	// and we don't already have it
+	if irc.userHost == "" && !irc.userHostRequested {
+		requestUserhost = true
+		irc.userHostRequested = true
+	}
+
+	return irc.currentNick, irc.userHost
 }
 
 // Calculate the max message size for PRIVMSG or NOTICE, after accounting
@@ -515,11 +532,10 @@ func (irc *Connection) getUserHost() string {
 // can change the client's NUH unilaterally at any time; implementations may
 // wish to use a more conservative constant maximum instead.
 func (irc *Connection) MaxMsgByteLen(target string) int {
-	nick := irc.CurrentNick()
-	userhost := irc.getUserHost()
+	nick, userHost := irc.getOrRequestUserHost()
 	var userhostLen int
-	if userhost != "" {
-		userhostLen = len(userhost)
+	if userHost != "" {
+		userhostLen = len(userHost)
 	} else {
 		userhostLen = 96 // sane default
 	}
@@ -660,6 +676,7 @@ func (irc *Connection) Connect() (err error) {
 		irc.socket = nil
 		irc.currentNick = ""
 		irc.userHost = ""
+		irc.userHostRequested = false
 		irc.lastError = nil
 		irc.pingSent = false
 

--- a/ircevent/irc.go
+++ b/ircevent/irc.go
@@ -501,6 +501,42 @@ func (irc *Connection) CurrentNick() string {
 	return irc.currentNick
 }
 
+// Calculate the max message size based on the premable byte length
+//
+// This may be used to ensure sent messages do not exceed the IRC 512 byte
+// limit.
+func (irc *Connection) MaxMsgByteLen(command, target string) int {
+	nick := irc.CurrentNick()
+	var userHost string
+	if irc.userHost != "" {
+		userHost = strings.TrimLeft(irc.userHost, "+-")
+	} else {
+		// Max length defaults, they are used if we can't get the values from
+		// ISUPPORT
+		hostLen := 63
+		userLen := 20
+		if userLenStr := irc.ISupport()["USERLEN"]; userLenStr != "" {
+			iSupportUserLen, err := strconv.Atoi(userLenStr)
+			if err == nil {
+				userLen = iSupportUserLen
+			}
+		}
+		if hostLenStr := irc.ISupport()["HOSTLEN"]; hostLenStr != "" {
+			iSupportHostLen, err := strconv.Atoi(hostLenStr)
+			if err == nil {
+				hostLen = iSupportHostLen
+			}
+		}
+		userHost = fmt.Sprintf(
+			"%s@%s",
+			strings.Repeat("A", userLen),
+			strings.Repeat("A", hostLen),
+		)
+	}
+	preamble := fmt.Sprintf(":%s!%s %s %s :\r\n", nick, userHost, command, target)
+	return 512 - len(preamble)
+}
+
 // Returns the expected or desired nickname for the connection;
 // if the real nickname is different, the client will periodically
 // attempt to change to this one.
@@ -831,6 +867,9 @@ CAPLOOP:
 	// wait for registration to complete, or fail
 	select {
 	case <-irc.welcomeChan:
+		// Send a USERHOST query so we can populate irc.userHost and use its
+		// value to accurately determine the MaxMsgByteLen()
+		irc.Send("USERHOST", irc.CurrentNick())
 		return nil
 	case <-timer.C:
 		return ServerTimedOut

--- a/ircevent/irc.go
+++ b/ircevent/irc.go
@@ -716,6 +716,12 @@ func (irc *Connection) Connect() (err error) {
 				irc.RequestCaps = append(irc.RequestCaps, "sasl")
 			}
 		}
+		if irc.FetchUserHost {
+			// ensure 'chghost' is in the cap list if necessary
+			if !sliceContains("chghost", irc.RequestCaps) {
+				irc.RequestCaps = append(irc.RequestCaps, "chghost")
+			}
+		}
 		if irc.SASLMech == "" {
 			irc.SASLMech = "PLAIN"
 		}

--- a/ircevent/irc_callback.go
+++ b/ircevent/irc_callback.go
@@ -423,10 +423,6 @@ func (irc *Connection) setupCallbacks() {
 	// Set irc.currentNick to the actually used nick in this connection.
 	irc.AddCallback(RPL_WELCOME, irc.handleRplWelcome)
 
-	// 302: RPL_USERHOST "bubbles=+~u@un4ncby3zwhc4.irc"
-	// Set irc.userHost to the returned value for our nick
-	irc.AddCallback(RPL_USERHOST, irc.handleRplUserhost)
-
 	// 005: RPL_ISUPPORT, conveys supported server features
 	irc.AddCallback(RPL_ISUPPORT, irc.handleISupport)
 
@@ -462,6 +458,16 @@ func (irc *Connection) setupCallbacks() {
 	irc.AddCallback("FAIL", irc.handleStandardReplies)
 	irc.AddCallback("WARN", irc.handleStandardReplies)
 	irc.AddCallback("NOTE", irc.handleStandardReplies)
+
+	// extensions for learning the user/host
+	irc.AddCallback("CHGHOST", irc.handleChghost)
+	irc.AddCallback("SETNAME", irc.handleSetname)
+
+	if irc.FetchUserHost {
+		irc.AddConnectCallback(func(_ ircmsg.Message) {
+			irc.getOrRequestUserHost()
+		})
+	}
 }
 
 func (irc *Connection) handleRplWelcome(e ircmsg.Message) {
@@ -474,37 +480,56 @@ func (irc *Connection) handleRplWelcome(e ircmsg.Message) {
 	}
 }
 
-func (irc *Connection) handleRplUserhost(e ircmsg.Message) {
-	if len(e.Params) != 2 {
+func (irc *Connection) handleSetname(e ircmsg.Message) {
+	// SETNAME always refers to the recipient:
+	// nick!user@host SETNAME :real name
+	var userHost string
+	if idx := strings.IndexByte(e.Source, '!'); idx != -1 {
+		userHost = e.Source[idx+1:]
+	}
+
+	if userHost == "" {
 		return
 	}
-	// "The last parameter of this numeric (if there are any results) is a
-	// list of <reply> values, delimited by a SPACE character (' ', 0x20)."
-	param := e.Params[1]
-	if strings.IndexByte(param, ' ') != -1 {
+
+	irc.stateMutex.Lock()
+	defer irc.stateMutex.Unlock()
+	irc.userHost = userHost
+}
+
+func (irc *Connection) handleChghost(e ircmsg.Message) {
+	// CHGHOST can refer to anyone:
+	// origNick!origUser@origHost CHGHOST newUser newHost
+	if len(e.Params) < 2 {
 		return
 	}
 	currentNick := irc.CurrentNick()
-	if currentNick == "" {
+	if !strings.HasPrefix(e.Source, currentNick) {
 		return
 	}
-	param, foundNick := strings.CutPrefix(param, currentNick)
-	if !foundNick {
+	if len(currentNick) == len(e.Source) || e.Source[len(currentNick)] != '!' {
 		return
 	}
-	// remove * if present:
-	// "<isop> is included if the user with the nickname of <nickname>
-	// has registered as an operator."
-	if len(param) != 0 && param[0] == '*' {
-		param = param[1:]
-	}
-	// "=", then either '+' or '-' indicating away status, then user@host
-	if len(param) < 3 || param[0] != '=' {
-		return
-	}
+	// ok, this is exactly our nick
+	userHost := fmt.Sprintf("%s@%s", e.Params[0], e.Params[1])
 	irc.stateMutex.Lock()
 	defer irc.stateMutex.Unlock()
-	irc.userHost = param[2:]
+	irc.userHost = userHost
+}
+
+func (irc *Connection) handleRplWhoReply(e ircmsg.Message) {
+	// 352 RPL_WHOREPLY, which we use to determine the client's own userhost:
+	// "<client> <channel> <username> <host> <server> <nick> <flags> :<hopcount> <realname>"
+	if len(e.Params) != 8 {
+		return
+	}
+	if e.Params[5] != irc.CurrentNick() {
+		return
+	}
+	userHost := fmt.Sprintf("%s@%s", e.Params[2], e.Params[3])
+	irc.stateMutex.Lock()
+	defer irc.stateMutex.Unlock()
+	irc.userHost = userHost
 }
 
 func (irc *Connection) handleRegistration(e ircmsg.Message) {
@@ -513,14 +538,6 @@ func (irc *Connection) handleRegistration(e ircmsg.Message) {
 	defer func() {
 		if becameRegistered {
 			close(irc.welcomeChan)
-		}
-	}()
-
-	var currentNick string
-	sendUserhost := false
-	defer func() {
-		if becameRegistered && sendUserhost {
-			irc.Send("USERHOST", currentNick)
 		}
 	}()
 
@@ -536,9 +553,6 @@ func (irc *Connection) handleRegistration(e ircmsg.Message) {
 	// mark the isupport complete
 	irc.isupport = irc.isupportPartial
 	irc.isupportPartial = nil
-
-	currentNick = irc.currentNick
-	sendUserhost = irc.userHost == ""
 }
 
 func (irc *Connection) handleUnavailableNick(e ircmsg.Message) {

--- a/ircevent/irc_callback.go
+++ b/ircevent/irc_callback.go
@@ -481,16 +481,14 @@ func (irc *Connection) handleRplWelcome(e ircmsg.Message) {
 }
 
 func (irc *Connection) handleSetname(e ircmsg.Message) {
-	// SETNAME always refers to the recipient:
-	// nick!user@host SETNAME :real name
-	var userHost string
-	if idx := strings.IndexByte(e.Source, '!'); idx != -1 {
-		userHost = e.Source[idx+1:]
-	}
-
-	if userHost == "" {
+	nuh, err := ircmsg.ParseNUH(e.Source)
+	if err != nil {
 		return
 	}
+	if nuh.Name == "" || nuh.Name != irc.CurrentNick() || nuh.User == "" || nuh.Host == "" {
+		return
+	}
+	userHost := e.Source[len(nuh.Name)+1:]
 
 	irc.stateMutex.Lock()
 	defer irc.stateMutex.Unlock()
@@ -503,14 +501,14 @@ func (irc *Connection) handleChghost(e ircmsg.Message) {
 	if len(e.Params) < 2 {
 		return
 	}
-	currentNick := irc.CurrentNick()
-	if !strings.HasPrefix(e.Source, currentNick) {
+	nuh, err := ircmsg.ParseNUH(e.Source)
+	if err != nil {
 		return
 	}
-	if len(currentNick) == len(e.Source) || e.Source[len(currentNick)] != '!' {
+	if nuh.Name == "" || nuh.Name != irc.CurrentNick() || nuh.User == "" || nuh.Host == "" {
 		return
 	}
-	// ok, this is exactly our nick
+	// ok, this refers to us
 	userHost := fmt.Sprintf("%s@%s", e.Params[0], e.Params[1])
 	irc.stateMutex.Lock()
 	defer irc.stateMutex.Unlock()

--- a/ircevent/irc_callback.go
+++ b/ircevent/irc_callback.go
@@ -474,29 +474,37 @@ func (irc *Connection) handleRplWelcome(e ircmsg.Message) {
 	}
 }
 
-// If irc.userHost is unset
-// - Parse RPL_USERHOST messages for our nick
-// - Set irc.userHost
 func (irc *Connection) handleRplUserhost(e ircmsg.Message) {
-	if irc.userHost != "" {
-		return
-	}
 	if len(e.Params) != 2 {
 		return
 	}
-	userHostNicks := strings.Split(e.Params[1], " ")
-	if len(userHostNicks) != 1 {
+	// "The last parameter of this numeric (if there are any results) is a
+	// list of <reply> values, delimited by a SPACE character (' ', 0x20)."
+	param := e.Params[1]
+	if strings.IndexByte(param, ' ') != -1 {
 		return
 	}
-	userHost, foundNick := strings.CutPrefix(
-		userHostNicks[0],
-		fmt.Sprintf("%s=", irc.CurrentNick()),
-	)
-	if foundNick {
-		irc.stateMutex.Lock()
-		defer irc.stateMutex.Unlock()
-		irc.userHost = userHost
+	currentNick := irc.CurrentNick()
+	if currentNick == "" {
+		return
 	}
+	param, foundNick := strings.CutPrefix(param, currentNick)
+	if !foundNick {
+		return
+	}
+	// remove * if present:
+	// "<isop> is included if the user with the nickname of <nickname>
+	// has registered as an operator."
+	if len(param) != 0 && param[0] == '*' {
+		param = param[1:]
+	}
+	// "=", then either '+' or '-' indicating away status, then user@host
+	if len(param) < 3 || param[0] != '=' {
+		return
+	}
+	irc.stateMutex.Lock()
+	defer irc.stateMutex.Unlock()
+	irc.userHost = param[2:]
 }
 
 func (irc *Connection) handleRegistration(e ircmsg.Message) {
@@ -505,6 +513,14 @@ func (irc *Connection) handleRegistration(e ircmsg.Message) {
 	defer func() {
 		if becameRegistered {
 			close(irc.welcomeChan)
+		}
+	}()
+
+	var currentNick string
+	sendUserhost := false
+	defer func() {
+		if becameRegistered && sendUserhost {
+			irc.Send("USERHOST", currentNick)
 		}
 	}()
 
@@ -521,6 +537,8 @@ func (irc *Connection) handleRegistration(e ircmsg.Message) {
 	irc.isupport = irc.isupportPartial
 	irc.isupportPartial = nil
 
+	currentNick = irc.currentNick
+	sendUserhost = irc.userHost == ""
 }
 
 func (irc *Connection) handleUnavailableNick(e ircmsg.Message) {

--- a/ircevent/irc_callback.go
+++ b/ircevent/irc_callback.go
@@ -423,6 +423,10 @@ func (irc *Connection) setupCallbacks() {
 	// Set irc.currentNick to the actually used nick in this connection.
 	irc.AddCallback(RPL_WELCOME, irc.handleRplWelcome)
 
+	// 302: RPL_USERHOST "bubbles=+~u@un4ncby3zwhc4.irc"
+	// Set irc.userHost to the returned value for our nick
+	irc.AddCallback(RPL_USERHOST, irc.handleRplUserhost)
+
 	// 005: RPL_ISUPPORT, conveys supported server features
 	irc.AddCallback(RPL_ISUPPORT, irc.handleISupport)
 
@@ -467,6 +471,31 @@ func (irc *Connection) handleRplWelcome(e ircmsg.Message) {
 	// set the nickname we actually received from the server
 	if len(e.Params) > 0 {
 		irc.currentNick = e.Params[0]
+	}
+}
+
+// If irc.userHost is unset
+// - Parse RPL_USERHOST messages for our nick
+// - Set irc.userHost
+func (irc *Connection) handleRplUserhost(e ircmsg.Message) {
+	if irc.userHost != "" {
+		return
+	}
+	if len(e.Params) != 2 {
+		return
+	}
+	userHostNicks := strings.Split(e.Params[1], " ")
+	if len(userHostNicks) != 1 {
+		return
+	}
+	userHost, foundNick := strings.CutPrefix(
+		userHostNicks[0],
+		fmt.Sprintf("%s=", irc.CurrentNick()),
+	)
+	if foundNick {
+		irc.stateMutex.Lock()
+		defer irc.stateMutex.Unlock()
+		irc.userHost = userHost
 	}
 }
 

--- a/ircevent/irc_struct.go
+++ b/ircevent/irc_struct.go
@@ -66,6 +66,7 @@ type Connection struct {
 	Debug           bool
 	AllowPanic      bool // if set, don't recover() from panics in callbacks
 	AllowTruncation bool // if set, truncate lines exceeding MaxLineLen and send them
+	FetchUserHost   bool // if set, attempt to retrieve userhost on connect so that MaxMsgByteLen works
 	// set this to configure how the connection is made (e.g. via a proxy server):
 	DialContext func(ctx context.Context, network, addr string) (net.Conn, error)
 
@@ -83,14 +84,15 @@ type Connection struct {
 	pingSent   bool      // we sent PING and are waiting for PONG
 
 	// IRC protocol connection state
-	currentNick     string // nickname assigned by the server, empty before registration
-	userHost        string // user@host assigned by the server, empty until RPL_USERHOST
-	capsAdvertised  map[string]string
-	capsAcked       map[string]string
-	isupport        map[string]string
-	isupportPartial map[string]string
-	nickCounter     int
-	registered      bool
+	currentNick       string // nickname assigned by the server, empty before registration
+	userHost          string // user@host assigned by the server, empty until RPL_USERHOST
+	capsAdvertised    map[string]string
+	capsAcked         map[string]string
+	isupport          map[string]string
+	isupportPartial   map[string]string
+	nickCounter       int
+	registered        bool
+	userHostRequested bool
 	// Connect() builds these with sufficient capacity to receive all expected
 	// responses during negotiation. Sends to them are nonblocking, so anything
 	// sent outside of negotiation will not cause the relevant callbacks to block.

--- a/ircevent/irc_struct.go
+++ b/ircevent/irc_struct.go
@@ -83,7 +83,10 @@ type Connection struct {
 	pingSent   bool      // we sent PING and are waiting for PONG
 
 	// IRC protocol connection state
-	currentNick     string // nickname assigned by the server, empty before registration
+	currentNick string // nickname assigned by the server, empty before registration
+	// userhost assigned by the server, empty before a USERHOST reply for our
+	// nick is recevied by irc.handleRplUserhost
+	userHost        string
 	capsAdvertised  map[string]string
 	capsAcked       map[string]string
 	isupport        map[string]string

--- a/ircevent/irc_struct.go
+++ b/ircevent/irc_struct.go
@@ -83,10 +83,8 @@ type Connection struct {
 	pingSent   bool      // we sent PING and are waiting for PONG
 
 	// IRC protocol connection state
-	currentNick string // nickname assigned by the server, empty before registration
-	// userhost assigned by the server, empty before a USERHOST reply for our
-	// nick is recevied by irc.handleRplUserhost
-	userHost        string
+	currentNick     string // nickname assigned by the server, empty before registration
+	userHost        string // user@host assigned by the server, empty until RPL_USERHOST
 	capsAdvertised  map[string]string
 	capsAcked       map[string]string
 	isupport        map[string]string

--- a/ircevent/irc_test.go
+++ b/ircevent/irc_test.go
@@ -90,45 +90,67 @@ func TestIRCemptyNick(t *testing.T) {
 }
 
 func TestIRCMaxMsgByteLen(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping test in short mode.")
-	}
 	ircnick1 := randStr(8)
 	irccon := connForTesting(ircnick1, "go-eventirc", false)
-	err := irccon.Connect()
-	if err != nil {
-		t.Log(err.Error())
-		t.Errorf("Can't connect to freenode.")
-	}
 	debugTest(irccon)
-	maxMsgByteLen := irccon.MaxMsgByteLen("PRIVMSG", ircnick1)
-	msg := randStr(maxMsgByteLen)
+	gotUserhost := make(chan struct{})
+	done := make(chan struct{})
+	irccon.AddCallback(RPL_USERHOST, func(e ircmsg.Message) {
+		// hack for synchronization, wait until RPL_USERHOST was received and processed
+		// (otherwise we're just testing the fallback value)
+		close(gotUserhost)
+	})
+	expectedFail := false
 	irccon.AddCallback(ERR_INPUTTOOLONG, func(e ircmsg.Message) {
 		if e.Params[0] == ircnick1 {
-			t.Errorf("ERR_INPUTTOOLONG: %v", e.Params[1])
+			if !expectedFail {
+				t.Errorf("ERR_INPUTTOOLONG: %v", e.Params[1])
+			}
+			done <- struct{}{}
 		}
 	})
 	var rcvdMsg string
 	irccon.AddCallback("PRIVMSG", func(e ircmsg.Message) {
 		if e.Nick() == ircnick1 {
 			rcvdMsg = e.Params[1]
+			done <- struct{}{}
 		}
 	})
+	err := irccon.Connect()
+	if err != nil {
+		t.Log(err.Error())
+		t.Errorf("Can't connect to testing ircd.")
+	}
+	<-gotUserhost
+	// now MaxMsgByteLen should return the real upper bound
+	maxMsgByteLen := irccon.MaxMsgByteLen(ircnick1)
+	msg := randStr(maxMsgByteLen)
 	err = irccon.Privmsg(ircnick1, msg)
 	if err != nil {
 		t.Errorf("Unable to send privmsg: %v", err)
 	}
-	// Wait for ERR_INPUTTOOLONG and PRIVMSG callbacks to pop
-	time.Sleep(100 * time.Millisecond)
+	<-done
 	if msg != rcvdMsg {
 		t.Errorf("Messages do not match: sent: '%v', received: '%v'", msg, rcvdMsg)
+	}
+
+	// test that the bound is sharp by adding one byte to the message
+	expectedFail = true
+	msg += "!"
+	rcvdMsg = ""
+	err = irccon.Privmsg(ircnick1, msg)
+	if err != nil {
+		t.Errorf("Unable to send privmsg: %v", err)
+	}
+	<-done
+	// message should either be relayed with truncation, or rejected,
+	// depending on implementation
+	if msg == rcvdMsg {
+		t.Errorf("Successfully relayed message over MaxMsgByteLen() bytes: %d", len(msg))
 	}
 }
 
 func TestConnection(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping test in short mode.")
-	}
 	rand.Seed(time.Now().UnixNano())
 	ircnick1 := randStr(8)
 	ircnick2 := randStr(8)

--- a/ircevent/irc_test.go
+++ b/ircevent/irc_test.go
@@ -93,10 +93,11 @@ func TestIRCMaxMsgByteLen(t *testing.T) {
 	ircnick1 := randStr(8)
 	irccon := connForTesting(ircnick1, "go-eventirc", false)
 	debugTest(irccon)
+	irccon.FetchUserHost = true
 	gotUserhost := make(chan struct{})
 	done := make(chan struct{})
-	irccon.AddCallback(RPL_USERHOST, func(e ircmsg.Message) {
-		// hack for synchronization, wait until RPL_USERHOST was received and processed
+	irccon.AddCallback(RPL_WHOREPLY, func(e ircmsg.Message) {
+		// hack for synchronization, wait until RPL_WHOREPLY was received and processed
 		// (otherwise we're just testing the fallback value)
 		close(gotUserhost)
 	})

--- a/ircevent/irc_test.go
+++ b/ircevent/irc_test.go
@@ -89,6 +89,42 @@ func TestIRCemptyNick(t *testing.T) {
 	}
 }
 
+func TestIRCMaxMsgByteLen(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+	ircnick1 := randStr(8)
+	irccon := connForTesting(ircnick1, "go-eventirc", false)
+	err := irccon.Connect()
+	if err != nil {
+		t.Log(err.Error())
+		t.Errorf("Can't connect to freenode.")
+	}
+	debugTest(irccon)
+	maxMsgByteLen := irccon.MaxMsgByteLen("PRIVMSG", ircnick1)
+	msg := randStr(maxMsgByteLen)
+	irccon.AddCallback(ERR_INPUTTOOLONG, func(e ircmsg.Message) {
+		if e.Params[0] == ircnick1 {
+			t.Errorf("ERR_INPUTTOOLONG: %v", e.Params[1])
+		}
+	})
+	var rcvdMsg string
+	irccon.AddCallback("PRIVMSG", func(e ircmsg.Message) {
+		if e.Nick() == ircnick1 {
+			rcvdMsg = e.Params[1]
+		}
+	})
+	err = irccon.Privmsg(ircnick1, msg)
+	if err != nil {
+		t.Errorf("Unable to send privmsg: %v", err)
+	}
+	// Wait for ERR_INPUTTOOLONG and PRIVMSG callbacks to pop
+	time.Sleep(100 * time.Millisecond)
+	if msg != rcvdMsg {
+		t.Errorf("Messages do not match: sent: '%v', received: '%v'", msg, rcvdMsg)
+	}
+}
+
 func TestConnection(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")


### PR DESCRIPTION
Add a function to calculate the maximum message size in bytes based on the nick, userhost, command, and target of the message to be sent.

This is useful when sending a long message that may need to be wrapped into multiple messages, in order to be sent.

The implementation was inspired by Catgirl's and Konversation's.