### PR TITLE
ircmsg: add WordWrap function

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/ergochat/irc-go
 
 go 1.15
+
+require github.com/rivo/uniseg v0.4.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
+github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=

--- a/ircmsg/unicode.go
+++ b/ircmsg/unicode.go
@@ -4,7 +4,10 @@
 package ircmsg
 
 import (
+	"strings"
 	"unicode/utf8"
+
+	"github.com/rivo/uniseg"
 )
 
 // TruncateUTF8Safe truncates a message, respecting UTF8 boundaries. If a message
@@ -26,4 +29,128 @@ func TruncateUTF8Safe(message string, byteLimit int) (result string) {
 		}
 	}
 	return message
+}
+
+// WordWrap modified version from tview[1]
+// - Removed parsing of tview style tags
+// - Changed the width paramater from number of screen cells to byte length
+//   as needed by IRC
+//
+// [1] https://github.com/rivo/tview/blob/v0.42.0/strings.go#L551
+
+// stepState represents the current state of the parser implemented in [step].
+type stepState struct {
+	unisegState int // The state of the uniseg parser.
+	boundaries  int // Information about boundaries, as returned by uniseg.Step.
+}
+
+// LineBreak returns whether the string can be broken into the next line after
+// the returned grapheme cluster. If optional is true, the line break is
+// optional. If false, the line break is mandatory, e.g. after a newline
+// character.
+func (s *stepState) LineBreak() (lineBreak, optional bool) {
+	switch s.boundaries & uniseg.MaskLine {
+	case uniseg.LineCanBreak:
+		return true, true
+	case uniseg.LineMustBreak:
+		return true, false
+	}
+	return false, false // uniseg.LineDontBreak.
+}
+
+// step uses uniseg.Step to iterate over the grapheme clusters of a string
+//
+// This function can be called consecutively to extract all grapheme clusters
+// from str. The return values are the first grapheme cluster, the remaining
+// string, and the new state. Pass the remaining string and the returned state
+// to the next call. If the rest string is empty, parsing is complete. Call the
+// returned state's methods for boundary and cluster width information.
+//
+// Pass nil for state on the first call.
+//
+// There is no need to call uniseg.HasTrailingLineBreakInString on the last
+// non-empty cluster as this function will do this for you and adjust the
+// returned boundaries accordingly.
+func step(str string, state *stepState) (cluster, rest string, newState *stepState) {
+	// Set up initial state.
+	if state == nil {
+		state = &stepState{
+			unisegState: -1,
+		}
+	}
+	if len(str) == 0 {
+		newState = state
+		return
+	}
+
+	// Get a grapheme cluster.
+	preState := state.unisegState
+	cluster, rest, state.boundaries, state.unisegState = uniseg.StepString(str, preState)
+	if rest == "" {
+		if !uniseg.HasTrailingLineBreakInString(cluster) {
+			state.boundaries &^= uniseg.MaskLine
+		}
+	}
+
+	newState = state
+	return
+}
+
+// WordWrap splits a text such that each resulting line does not exceed the
+// given number of bytes. Split points are determined using the algorithm
+// described in [Unicode Standard Annex #14].
+//
+// [Unicode Standard Annex #14]: https://www.unicode.org/reports/tr14/
+func WordWrap(text string, byteWidth int) (lines []string) {
+	if byteWidth <= 0 {
+		return
+	}
+
+	var (
+		state      *stepState
+		lineLength int
+		lastOption int
+		cluster    string
+	)
+	str := text
+	for len(str) > 0 {
+		// Parse the next character.
+		cluster, str, state = step(str, state)
+		graphemeBytes := len(cluster)
+
+		// Would it exceed the line byteWidth?
+		if lineLength+graphemeBytes > byteWidth {
+			if lastOption == 0 {
+				// No split point so far. Just split at the current position.
+				lines = append(lines, text[:lineLength])
+				text = text[lineLength:]
+				lineLength, lastOption = 0, 0
+			} else {
+				// Split at the last split point.
+				lines = append(lines, text[:lastOption])
+				text = text[lastOption:]
+				lineLength -= lastOption
+				lastOption = 0
+			}
+		}
+
+		// Move ahead.
+		lineLength += graphemeBytes
+
+		// Check for split points.
+		if lineBreak, optional := state.LineBreak(); lineBreak {
+			if optional {
+				// Remember this split point.
+				lastOption = lineLength
+			} else {
+				// We must split here.
+				lines = append(lines, strings.TrimRight(text[:lineLength], "\n\r"))
+				text = text[lineLength:]
+				lineLength, lastOption = 0, 0
+			}
+		}
+	}
+	lines = append(lines, text)
+
+	return
 }

--- a/ircmsg/unicode_test.go
+++ b/ircmsg/unicode_test.go
@@ -4,6 +4,7 @@
 package ircmsg
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -34,5 +35,57 @@ func BenchmarkTruncateUTF8Invalid(b *testing.B) {
 func BenchmarkTruncateUTF8Valid(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		TruncateUTF8Safe("12345🐬", 8)
+	}
+}
+
+type wordWrapTest struct {
+	input  string
+	width  int
+	output []string
+}
+
+var wordWrapTests = []wordWrapTest{
+	{
+		`🍩 boo baz`,
+		10,
+		[]string{
+			`🍩 boo `,
+			`baz`,
+		},
+	},
+	{
+		`boo baz bar`,
+		4,
+		[]string{
+			`boo `,
+			`baz `,
+			`bar`,
+		},
+	},
+	{
+		`boo baz bar`,
+		10,
+		[]string{
+			`boo baz `,
+			`bar`,
+		},
+	},
+	{
+		"YOU may remember, my dear friend, that when we lately spent that happy day in the delightful garden and sweet society of the Moulin Joly, I stopped a little in one of our walks, and stayed some time behind the company. We had been shown numberless skeletons of a kind of little fly, called an ephemera, whose successive generations, we were told, were bred and expired within the day. I happened to see a living company of them on a leaf, who appeared to be engaged in conversation. You know I understand all the inferior animal tongues. My too great application to the study of them is the best excuse I can give for the little progress I have made in your charming language. I listened through curiosity to the discourse of these little creatures; but as they, in their national vivacity, spoke three or four together, I could make but little of their conversation. I found, however, by some broken expressions that I heard now and then, they were disputing warmly on the merit of two foreign musicians, one a cousin, the other a moscheto; in which dispute they spent their time, seemingly as regardless of the shortness of life as if they had been sure of living a month. Happy people! thought I; you are certainly under a wise, just, and mild government, since you have no public grievances to complain of, nor any subject of contention but the perfections and imperfections of foreign music. I turned my head from them to an old gray-headed one, who was single on another leaf, and talking to himself. Being amused with his soliloquy, I put it down in writing, in hopes it will likewise amuse her to whom I am so much indebted for the most pleasing of all amusements, her delicious company and heavenly harmony.",
+		512,
+		[]string{
+			"YOU may remember, my dear friend, that when we lately spent that happy day in the delightful garden and sweet society of the Moulin Joly, I stopped a little in one of our walks, and stayed some time behind the company. We had been shown numberless skeletons of a kind of little fly, called an ephemera, whose successive generations, we were told, were bred and expired within the day. I happened to see a living company of them on a leaf, who appeared to be engaged in conversation. You know I understand all ",
+			"the inferior animal tongues. My too great application to the study of them is the best excuse I can give for the little progress I have made in your charming language. I listened through curiosity to the discourse of these little creatures; but as they, in their national vivacity, spoke three or four together, I could make but little of their conversation. I found, however, by some broken expressions that I heard now and then, they were disputing warmly on the merit of two foreign musicians, one a cousin, ",
+			"the other a moscheto; in which dispute they spent their time, seemingly as regardless of the shortness of life as if they had been sure of living a month. Happy people! thought I; you are certainly under a wise, just, and mild government, since you have no public grievances to complain of, nor any subject of contention but the perfections and imperfections of foreign music. I turned my head from them to an old gray-headed one, who was single on another leaf, and talking to himself. Being amused with his ",
+			"soliloquy, I put it down in writing, in hopes it will likewise amuse her to whom I am so much indebted for the most pleasing of all amusements, her delicious company and heavenly harmony."},
+	},
+}
+
+func TestWordWrap(t *testing.T) {
+	for _, test := range wordWrapTests {
+		output := WordWrap(test.input, test.width)
+		assertEqual(test.output, output)
+		// Ensure that if we unwrap the string, it is the same as the original
+		assertEqual(test.input, strings.Join(output, ""))
 	}
 }


### PR DESCRIPTION
Add a function to wrap a message to a specific byte length, so a message longer than IRC's limit can be split into multiple messages before being sent.

After searching for a suitable library, that accounts for UTF-8 graphemes, uniseg seemed the best available. The same author's tview library implements word wrapping, but in a way specific for that library. This version takes the MIT licensed code and logic from tview with minor modifications:
  - Removed parsing of tview style tags
  - Changed the width paramater from number of screen cells to byte length as needed by IRC