### PR TITLE
update CI config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,10 +13,12 @@ jobs:
     runs-on: "ubuntu-22.04"
     steps:
       - name: "checkout repository"
-        uses: "actions/checkout@v3"
+        uses: "actions/checkout@v6"
       - name: "setup go"
-        uses: "actions/setup-go@v3"
+        uses: "actions/setup-go@v6"
         with:
-          go-version: "1.20"
+          go-version: "1.17"
       - name: "make test"
         run: "make test"
+      - name: "compile ircevent"
+        run: "go build -v ircevent/examples/simple.go"


### PR DESCRIPTION
* Upgrade CI actions
* Downgrade Go to 1.17 to verify that we haven't unintentionally introduced generics (which are incompatible with gccgo)