### PR TITLE
tweak batch timeouts

### DIFF
--- a/ircevent/irc.go
+++ b/ircevent/irc.go
@@ -147,10 +147,7 @@ func (irc *Connection) readLoop() {
 		}
 
 		if irc.batchNegotiated() && time.Since(lastExpireCheck) > irc.Timeout {
-			if fatalErr := irc.expireBatches(false); fatalErr != nil {
-				irc.setError(fatalErr)
-				return
-			}
+			irc.expireBatches(false)
 			lastExpireCheck = time.Now()
 		}
 	}

--- a/ircevent/irc_callback.go
+++ b/ircevent/irc_callback.go
@@ -197,7 +197,6 @@ var (
 	errorMaxRecursionDepth   = errors.New("maximum batch nesting depth exceeded")
 	errorMaxTotalBatchSize   = errors.New("maximum total batched data exceeded limit")
 	errorInvalidBatchNesting = errors.New("invalid batch nesting detected")
-	errorBatchTimedOut       = errors.New("server opened a batch and didn't close it")
 )
 
 func (irc *Connection) handleBatchCommand(msg ircmsg.Message, rawMsg string) (fatalErr error) {
@@ -742,14 +741,8 @@ func (irc *Connection) unregisterLabel(labelStr string) {
 	delete(irc.labelCallbacks, label)
 }
 
-// check for two kinds of server batch failure:
-//   - labeled responses that never arrived (this is not fatal)
-//   - server batches that were opened and never closed (this is fatal
-//     because it corrupts the batch tracking state)
-//
-// `force` expires all label callbacks regardless of time (so they
-// can be triggered when the connection fails for any reason).
-func (irc *Connection) expireBatches(force bool) (fatalErr error) {
+// periodic task to expire labeled responses that never arrived
+func (irc *Connection) expireBatches(force bool) {
 	var failedCallbacks []LabelCallback
 	defer func() {
 		for _, bcb := range failedCallbacks {
@@ -762,19 +755,11 @@ func (irc *Connection) expireBatches(force bool) (fatalErr error) {
 	now := time.Now()
 
 	for label, lcb := range irc.labelCallbacks {
-		if force || now.Sub(lcb.createdAt) > irc.KeepAlive {
+		if force || now.Sub(lcb.createdAt) > irc.Timeout {
 			failedCallbacks = append(failedCallbacks, lcb.callback)
 			delete(irc.labelCallbacks, label)
 		}
 	}
-
-	for _, bip := range irc.batches {
-		if now.Sub(bip.createdAt) > irc.KeepAlive {
-			return errorBatchTimedOut
-		}
-	}
-
-	return nil
 }
 
 func splitCAPToken(token string) (name, value string) {


### PR DESCRIPTION
* Don't expire batches themselves, just let them count against MaxTotalBatchSize (this doesn't actually change the threat model in terms of servers being able to consume memory on the client)
* The labeled-response timeout is now `Timeout` (default 1 minute) instead of `KeepAlive` (default 4 minutes), same as for PING